### PR TITLE
fix logger level setting

### DIFF
--- a/lib/rubycas-server-core.rb
+++ b/lib/rubycas-server-core.rb
@@ -24,7 +24,7 @@ module RubyCAS
         Settings.load!(config_file)
         R18n.default_places = '../locales'
         R18n.set(Settings.default_locale)
-        $LOG.level = Settings.log[:level] || Logger::ERROR
+        $LOG.level = Logger.const_get(Settings.log[:level]) || Logger::ERROR
         Database.setup(Settings.database)
       end
     end


### PR DESCRIPTION
Logger actually uses an integer internally but gives us those nice little constants to refer to so we don't have some cryptic number floating around in our code/configs.

Signed-off-by: Tyler Pickett t.pickett66@gmail.com
