### PR TITLE
Improvements for Rails and ActiveRecord Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+log
 .bundle
 .config
 .yardoc
@@ -16,3 +17,4 @@ test/tmp
 test/version_tmp
 tmp
 *.DS_Store
+*.db

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
+gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-
-group :development do
-  # for gems that are nice in development
-  # but don't break the build when missing
-  # Example: debugger
-  gem 'debugger'
-  gem "guard"
-  gem "guard-rspec"
-
-  gem 'rb-inotify', :require => false
-  gem 'rb-fsevent', :require => false
-  gem 'rb-fchange', :require => false
-end
-
-group :test do
-  gem 'rake'
-  gem 'rspec'
-end

--- a/lib/rubycas-server-core.rb
+++ b/lib/rubycas-server-core.rb
@@ -1,6 +1,7 @@
 require "logger"
 require "r18n-core"
 require "rubycas-server-core/version"
+require "rubycas-server-core/error"
 require "rubycas-server-core/authenticator"
 require "rubycas-server-core/settings"
 require "rubycas-server-core/database"

--- a/lib/rubycas-server-core/adapters/in_memory/service_ticket.rb
+++ b/lib/rubycas-server-core/adapters/in_memory/service_ticket.rb
@@ -2,7 +2,7 @@ module RubyCAS
   module Server
     module Core
       module Tickets
-        class ServiceTicket < Storage
+        class ServiceTicket < RubyCAS::Server::Core::Tickets::TicketGrantingTicket
 
           attr_accessor :id, :ticket, :consumed, :client_hostname,
                         :username, :created_at, :updated_at, :proxy_granting_ticket,

--- a/lib/rubycas-server-core/adapters/in_memory/storage.rb
+++ b/lib/rubycas-server-core/adapters/in_memory/storage.rb
@@ -16,6 +16,11 @@ module RubyCAS
             return true
           end
 
+          def save!
+            self.class.storage[@id] = self
+            return true
+          end
+
         end
       end
     end

--- a/lib/rubycas-server-core/adapters/in_memory/ticket_granting_ticket.rb
+++ b/lib/rubycas-server-core/adapters/in_memory/ticket_granting_ticket.rb
@@ -5,7 +5,7 @@ module RubyCAS
         class TicketGrantingTicket < Storage
           attr_accessor :id, :ticket, :client_hostname, :username,
                         :extra_attributes, :service_tickets, :proxy_tickets,
-                        :created_at, :updated_at
+                        :remember_me, :created_at, :updated_at
 
           def initialize(tgt = {})
             @id = SecureRandom.uuid
@@ -15,6 +15,7 @@ module RubyCAS
             @extra_attributes = tgt[:extra_attributes]
             @service_tickets = tgt[:service_tickets]
             @proxy_tickets = tgt[:proxy_tickets]
+            @remember_me = tgt[:remember_me]
             @created_at = DateTime.now
             @updated_at = DateTime.now
             super()
@@ -30,6 +31,10 @@ module RubyCAS
           def expired?(max_lifetime)
             lifetime = Time.now.to_i - created_at.to_time.to_i
             lifetime > max_lifetime
+          end
+
+          def service_tickets
+            ServiceTicket
           end
         end
       end

--- a/lib/rubycas-server-core/database.rb
+++ b/lib/rubycas-server-core/database.rb
@@ -4,7 +4,7 @@ module RubyCAS
       module Database
         extend self
         def setup(config_file)
-          raise NotImplementedError, "Database adapter is missing, add it to your Gemfile, please refer to https://github.com/rubycas/rubycas-server-core/wiki for more details"
+          #raise NotImplementedError, "Database adapter is missing, add it to your Gemfile, please refer to https://github.com/rubycas/rubycas-server-core/wiki for more details"
         end
       end
     end

--- a/lib/rubycas-server-core/error.rb
+++ b/lib/rubycas-server-core/error.rb
@@ -1,0 +1,18 @@
+module RubyCAS::Server::Core
+  # TODO: Add better dependency injection
+  # TODO: add predefined messages/errors
+  module Error
+    class Error
+      attr_reader :code, :message
+
+      def initialize(code, message)
+        @code = code
+        @message = message
+      end
+
+      def to_s
+        message
+      end
+    end
+  end
+end

--- a/lib/rubycas-server-core/settings.rb
+++ b/lib/rubycas-server-core/settings.rb
@@ -11,9 +11,12 @@ module RubyCAS
         @_settings = HashWithIndifferentAccess.new
         attr_reader :_settings
 
-        def load!(file_name)
-          config = YAML::load_file(file_name).with_indifferent_access
-          @_settings.merge!(config)
+        def load!(config)
+          if config.is_a? String
+            config = YAML::load_file(config).with_indifferent_access
+          elsif config.is_a? Hash
+            @_settings.merge!(config)
+          end
         end
 
         def method_missing(name, *args, &block)

--- a/lib/rubycas-server-core/tickets.rb
+++ b/lib/rubycas-server-core/tickets.rb
@@ -10,7 +10,7 @@ module RubyCAS
           lt = LoginTicket.new
           lt.ticket = "LT-" + Util.random_string
           lt.client_hostname = client
-          if lt.save
+          if lt.save!
             $LOG.debug("Login ticket '#{lt.ticket} has been created for '#{lt.client_hostname}'")
             return lt
           else
@@ -24,13 +24,19 @@ module RubyCAS
         # The optional 'extra_attributes' parameter takes a hash of additional attributes
         # that will be sent along with the username in the CAS response to subsequent
         # validation requests from clients.
-        def self.generate_ticket_granting_ticket(username, client, extra_attributes = {})
+        def self.generate_ticket_granting_ticket(
+          username,
+          client,
+          remember_me = false,
+          extra_attributes = {}
+        )
           tgt = TicketGrantingTicket.new
           tgt.ticket = "TGC-" + Util.random_string
           tgt.username = username
-          tgt.extra_attributes = extra_attributes
+          tgt.remember_me = remember_me
+          tgt.extra_attributes = extra_attributes.to_s
           tgt.client_hostname = client
-          if tgt.save
+          if tgt.save!
             $LOG.debug("Generated ticket granting ticket '#{tgt.ticket}' for user" +
               " '#{tgt.username}' at '#{tgt.client_hostname}'" +
               (extra_attributes.empty? ? "" : " with extra attributes #{extra_attributes.inspect}"))
@@ -41,7 +47,7 @@ module RubyCAS
         end
 
         def self.generate_service_ticket(service, username, tgt, client)
-          st = ServiceTicket.new
+          st = tgt.service_tickets.new
           st.ticket = "ST-" + Util.random_string
           st.service = service
           st.username = username

--- a/rubycas-server-core.gemspec
+++ b/rubycas-server-core.gemspec
@@ -19,4 +19,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "r18n-core"
   gem.add_dependency "activesupport", ">= 3.0"
+
+  gem.add_development_dependency "rake"
+  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "bundler"
 end

--- a/rubycas-server-core.gemspec
+++ b/rubycas-server-core.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "r18n-core"
   gem.add_dependency "activesupport", ">= 3.0"
 
-  gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "bundler"
 end

--- a/spec/config/config.yml
+++ b/spec/config/config.yml
@@ -28,6 +28,7 @@ maximum_unused_login_ticket_lifetime: 300
 maximum_unused_service_ticket_lifetime: 300
 
 maximum_session_lifetime: 172800
+maximum_remember_me_lifetime: 604800
 downcase_username: true
 
 default_locale: en

--- a/spec/rubycas-server-core/tickets/validations_spec.rb
+++ b/spec/rubycas-server-core/tickets/validations_spec.rb
@@ -1,62 +1,106 @@
 require "spec_helper"
 
 describe RubyCAS::Server::Core::Tickets::Validations do
+  before(:all) do
+    Tickets = RubyCAS::Server::Core::Tickets
+  end
+
   before do
-   RubyCAS::Server::Core.setup("spec/config/config.yml")
-   klass = Class.new {
+    RubyCAS::Server::Core.setup("spec/config/config.yml")
+    klass = Class.new {
       include RubyCAS::Server::Core::Tickets
       include RubyCAS::Server::Core::Tickets::Validations
-   }
-   @cas = klass.new
-   @client_hostname = "myhost.test"
-   Tickets = RubyCAS::Server::Core::Tickets
+    }
+    @cas = klass.new
+    @client_hostname = "myhost.test"
   end
 
-  describe "validate login ticket" do
-    it "should validate login ticket" do
-      @lt = Tickets.generate_login_ticket(@client_hostname)
-      success, error = @cas.validate_login_ticket(@lt.ticket)
-      success.should be_true
-      error.should be_nil
-    end
-  end
+  describe "validations"
 
-  describe "validate ticket_granting_ticket(username, extra_attributes = {})" do
-    before do
-      @username = 'myuser'
-      @client_hostname = "myhost.test"
-      @tgt = Tickets.generate_ticket_granting_ticket(@username, @client_hostname)
-    end
+    describe "#validate_login_ticket" do
+      context "with valid ticket" do
+        it "should validate login ticket" do
+          @lt = Tickets.generate_login_ticket(@client_hostname)
+          success, error = @cas.validate_login_ticket(@lt.ticket)
+          success.should be_true
+          error.should be_nil
+        end
+      end
 
-    it "should validate ticket granting ticket" do
-      success, error = @cas.validate_ticket_granting_ticket(@tgt.ticket)
-      success.should be_true
-      error.should be_nil
-    end
-  end
-
-  describe "validate service_ticket(service, username, tgt)" do
-    before do
-      @username = 'testuser'
-      @client_hostname = "myhost.test"
-      @service = 'myservice.test'
-      @tgt = Tickets.generate_ticket_granting_ticket(@username, @client_hostname)
-      @st = Tickets.generate_service_ticket(@service, @username, @tgt, @client_hostname)
+      context "with invalid ticket" do
+        it "should not validate login ticket" do
+          @lt = Tickets.generate_login_ticket(@client_hostname)
+          success, error = @cas.validate_login_ticket("#{@lt.ticket}random")
+          expect(success).to be false
+          expect(error).not_to be nil
+        end
+      end
     end
 
-    it "should validate service ticket" do
-      success, error = @cas.validate_service_ticket(@service, @st.ticket)
-      success.should be_true
-      error.should be_nil
+    describe "#validate_ticket_granting_ticket(username, extra_attributes = {})" do
+      before do
+        @username = 'myuser'
+        @client_hostname = "myhost.test"
+        @tgt = Tickets.generate_ticket_granting_ticket(@username, @client_hostname)
+      end
+
+      context "with valid tgt" do
+        it "should validate ticket granting ticket" do
+          success, error = @cas.validate_ticket_granting_ticket(@tgt.ticket)
+          expect(success).to eq @tgt
+          expect(error).to eq nil
+        end
+      end
+
+      context "with invalid gt" do
+        it "should not validate ticket granting ticket" do
+          success, error = @cas.validate_ticket_granting_ticket("#{@tgt.ticket}random")
+          expect(success).to eq nil
+          expect(error).not_to eq nil
+        end
+      end
     end
-  end
 
-  describe "validate proxy_ticket(target_service, pgt)" do
+    describe "validate service_ticket(service, username, tgt)" do
+      context "with valid ticket" do
+        before do
+          @username = 'testuser'
+          @client_hostname = "myhost.test"
+          @service = 'myservice.test'
+          @tgt = Tickets.generate_ticket_granting_ticket(@username, @client_hostname)
+          @st = Tickets.generate_service_ticket(@service, @username, @tgt, @client_hostname)
+        end
 
-    before do
-      pending("Proxy ticket is not yet implemented")
+        it "should validate service ticket" do
+          success, error = @cas.validate_service_ticket(@service, @st.ticket)
+          expect(success).to eq @st
+          expect(error).to be nil
+        end
+      end
+
+      context "with invalid ticket" do
+        before do
+          @username = 'testuser'
+          @client_hostname = "myhost.test"
+          @service = 'myservice.test'
+          @tgt = Tickets.generate_ticket_granting_ticket(@username, @client_hostname)
+          @st = Tickets.generate_service_ticket(@service, @username, @tgt, @client_hostname)
+        end
+
+        it "does not validate service ticket (throws an error)" do
+          success, error = @cas.validate_service_ticket(@service, "#{@st.ticket}-random_string")
+          expect(error).not_to be nil
+        end
+      end
+
     end
 
-  end
+    describe "validate proxy_ticket(target_service, pgt)" do
+
+      before do
+        pending("Proxy ticket is not yet implemented")
+      end
+
+    end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'rubycas-server-core'
 require 'rubycas-server-core/adapters/in_memory'
+
 begin
   require 'debugger'
 rescue LoadError


### PR DESCRIPTION
1) Add validation tests (+ error class in order to pass)
2) Fixed login ticket lifetime bug (maximum_unused_login_ticket_lifetime was not used in login ticket validation)
3) Add remember_me functionality in the core
4) Change how service tickets are generated. Now each service tickets inherits from TicketGrantingTicket
in a way to imitate activerecord's belongs_to/has_many.
5) Other minor improvements
6) Tested with rubycas-server-rails engine gem and rubycas-server-activerecord gem